### PR TITLE
Preserve `.readthedocs.yml` configuration file from the Solidity repo when creating sync PRs

### DIFF
--- a/maintainer-guide.md
+++ b/maintainer-guide.md
@@ -71,7 +71,7 @@ git clone git@github.com:solidity-docs/<language-code>.git
 Remove files irrelevant to the translation
 ```
 cd <language-code>
-find . -mindepth 1 -maxdepth 1 ! \( -name "docs" -o -name "CMakeLists.txt" -o -name ".git" \) -exec git rm -r {} \;
+find . -mindepth 1 -maxdepth 1 ! \( -name "docs" -o -name "CMakeLists.txt" -o -name ".readthedocs.yml" -o -name ".git" \) -exec git rm -r {} \;
 ```
 
 Add a README

--- a/scripts/pull-and-resolve-english-changes.sh
+++ b/scripts/pull-and-resolve-english-changes.sh
@@ -25,7 +25,7 @@ if ! git merge "${SOLIDITY_REF}" -m "$COMMIT_MESSAGE"; then
 
     # The only changes from the main repo that we're interested in are those in docs/ and
     # CMakeLists.txt, which is parsed by our Sphinx config to determine version. Stage them.
-    git add docs/ CMakeLists.txt
+    git add docs/ CMakeLists.txt .readthedocs.yml
 
     # Reset any files seen by git as modified/deleted to the state from before the merge.
     # We need this for files outside of docs/ that happen to match the path of some file that exists


### PR DESCRIPTION
See https://github.com/solidity-docs/zh-chinese/pull/279 and https://blog.readthedocs.com/migrate-configuration-v2/ for context.